### PR TITLE
tklockinterface: add tklock property for rerunning when LPS is shown

### DIFF
--- a/billboardd/billboardd.pro
+++ b/billboardd/billboardd.pro
@@ -29,6 +29,9 @@ HEADERS += dithering.h
 SOURCES += network.cc
 HEADERS += network.h
 
+SOURCES += tklockinterface.cc
+HEADERS += tklockinterface.h
+
 SOURCES += volumeinterface.cc
 HEADERS += volumeinterface.h
 

--- a/billboardd/daemon.h
+++ b/billboardd/daemon.h
@@ -33,6 +33,7 @@ QTM_USE_NAMESPACE
 #include "gconfmon.h"
 #include "organizer.h"
 #include "network.h"
+#include "tklockinterface.h"
 #include "volumeinterface.h"
 #include "batteryicon.h"
 
@@ -71,6 +72,7 @@ class Daemon : public QObject {
               context(NULL),
               gconfmon(NULL),
               organizer(),
+              tklock(),
               volume(),
               updateTimer(),
               sysAlignedTimer(),
@@ -128,6 +130,9 @@ class Daemon : public QObject {
             QObject::connect(&sysAlignedTimer, SIGNAL(timeout()),
                     this, SLOT(sysAlignedUpdate()));
 
+            QObject::connect(&tklock, SIGNAL(locked()),
+                    this, SLOT(contextChanged()));
+
             enabledChanged();
             textChanged();
             render(true);
@@ -157,6 +162,7 @@ class Daemon : public QObject {
         Context *context;
         GConfMonitor *gconfmon;
         Organizer organizer;
+        TklockInterface tklock;
         VolumeInterface volume;
 
         QTimer updateTimer;

--- a/billboardd/tklockinterface.cc
+++ b/billboardd/tklockinterface.cc
@@ -1,0 +1,45 @@
+
+/**
+ * Billboard - Low Power Mode Standby Screen for the N9
+ * Webpage: http://thp.io/2012/billboard/
+ * Copyright (C) 2015 Elliot Wolk <elliot.wolk@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include "tklockinterface.h"
+
+#include <QDBusConnection>
+
+TklockInterface::TklockInterface() :
+    QObject(NULL),
+    m_lock_mode("")
+{
+    connect();
+}
+
+TklockInterface::~TklockInterface ()
+{
+}
+
+void TklockInterface::connect()
+{
+    QDBusConnection::systemBus().connect(
+      "",
+      "/com/nokia/mce/signal",
+      "com.nokia.mce.signal",
+      "tklock_mode_ind",
+      this,
+      SLOT(setLockMode(QString)));
+}

--- a/billboardd/tklockinterface.h
+++ b/billboardd/tklockinterface.h
@@ -1,0 +1,61 @@
+
+/**
+ * Billboard - Low Power Mode Standby Screen for the N9
+ * Webpage: http://thp.io/2012/billboard/
+ * Copyright (C) 2015 Elliot Wolk <elliot.wolk@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#ifndef TKLOCKINTERFACE_H
+#define TKLOCKINTERFACE_H
+
+#include <QObject>
+
+class TklockInterface : public QObject
+{
+    Q_OBJECT
+
+    public:
+        TklockInterface();
+        ~TklockInterface();
+
+        bool isLocked() {
+            return m_lock_mode == "locked";
+        }
+
+    public slots:
+        void setLockMode(QString lock_mode) {
+            if (m_lock_mode != lock_mode) {
+                m_lock_mode = lock_mode;
+                if (isLocked()) {
+                  emit locked();
+                } else {
+                  emit unlocked();
+                }
+            }
+        }
+
+    signals:
+        void locked();
+
+        void unlocked();
+
+    private:
+        void connect();
+
+        QString m_lock_mode;
+};
+
+#endif


### PR DESCRIPTION
one feature at a time so you can critique.  next feature will be adding a billboard dbus iface to trigger a rerun {or perhaps arbitrary prop setting, e.g.: qdbus io.thp.billboard / setProp "klomp-song" "Rinse the Raindrops"}
